### PR TITLE
tCrw/optimize reads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 #  limitations under the License.
 #
 REGISTRY := gcr.io/pm-registry/feast
-VERSION := v0.4-cassandra-versionless-10
+VERSION := v0.4-cassandra-fastread
 PROJECT_ROOT 	:= $(shell git rev-parse --show-toplevel)
 
 test:


### PR DESCRIPTION
Reads from cassandra should't read unneeded feature data, and include the builder time in the trace